### PR TITLE
Apply manifest configuration to deobf jar task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -130,12 +130,15 @@ fancyGradle {
     }
 }
 
+processJarTask jar
+
 if (project.build_deobfJar.toBoolean()) {
     // Create deobf dev jars
     task deobfJar(type: Jar) {
         archiveClassifier.set("deobf")
         from sourceSets.main.output
     }
+    processJarTask deobfJar
 }
 
 if (project.build_apiJar.toBoolean()) {
@@ -188,27 +191,6 @@ sourceSets {
     main.output.setResourcesDir(main.java.outputDir)
 }
 
-jar {
-    manifest {
-		// noinspection GroovyAssignabilityCheck
-		def attribute_map = [:]
-		if (project.use_coremod.toBoolean()) {
-			attribute_map['FMLCorePlugin'] = project.coremod_plugin_class_name
-			if (project.include_mod.toBoolean()) {
-				attribute_map['FMLCorePluginContainsFMLMod'] = true
-				attribute_map['ForceLoadAsMod'] = project.gradle.startParameter.taskNames[0] == 'build'
-			}
-		}
-		if (project.use_mixins.toBoolean()) {
-			attribute_map['TweakClass'] = 'org.spongepowered.asm.launch.MixinTweaker'
-		}
-        if (project.has_access_transformer.toBoolean()) {
-            attribute_map['FMLAT'] = project.archives_base_name + '_at.cfg'
-        }
-        attributes(attribute_map)
-    }
-}
-
 artifacts {
     if (project.build_deobfJar.toBoolean()) {
         archives deobfJar
@@ -241,5 +223,32 @@ processResources {
     // copy everything else except the mcmod.info
     from(sourceSets.main.resources.srcDirs) {
         exclude 'mcmod.info'
+    }
+}
+
+/**
+ * Applies required processing to jar tasks
+ * @param task the task to process
+ */
+private void processJarTask(task) {
+    task.configure {
+        manifest {
+            // noinspection GroovyAssignabilityCheck
+            def attribute_map = [:]
+            if (project.use_coremod.toBoolean()) {
+                attribute_map['FMLCorePlugin'] = project.coremod_plugin_class_name
+                if (project.include_mod.toBoolean()) {
+                    attribute_map['FMLCorePluginContainsFMLMod'] = true
+                    attribute_map['ForceLoadAsMod'] = project.gradle.startParameter.taskNames[0] == 'build'
+                }
+            }
+            if (project.use_mixins.toBoolean()) {
+                attribute_map['TweakClass'] = 'org.spongepowered.asm.launch.MixinTweaker'
+            }
+            if (project.has_access_transformer.toBoolean()) {
+                attribute_map['FMLAT'] = project.archives_base_name + '_at.cfg'
+            }
+            attributes(attribute_map)
+        }
     }
 }


### PR DESCRIPTION
This PR fixes an issue with depending on deobf jars. Since they did not receive the same configuration as the regular jar, their `MANIFEST.MF` file did not contain the required information for forge to load their Access Transformers. I believe this would also prevent their CoreMods, and Mixins from being loaded as well. This PR fixes this by applying the configuration to both tasks.