### PR TITLE
Feature: Overhaul branch patch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,11 +48,15 @@ jobs:
       - name: Publish to CurseForge
         if: steps.properties.outputs.publish_to_curseforge == 'true'
         uses: gradle/gradle-build-action@v2
+        env:
+          CURSEFORGE_TOKEN: ${{ secrets.CURSEFORGE_TOKEN }}
         with:
           arguments: curseforge
 
       - name: Publish to Modrinth
         if: steps.properties.outputs.publish_to_modrinth == 'true'
         uses: gradle/gradle-build-action@v2
+        env:
+          MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
         with:
           arguments: modrinth

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Template workspace for modding Minecraft 1.12.2. Licensed under MIT, it is made for public use.
 
-This template currently utilizies **Gradle 8.1.1** + **[RetroFuturaGradle](https://github.com/GTNewHorizons/RetroFuturaGradle) 1.3.19** + **Forge 14.23.5.2860**.
+This template currently utilizies **Gradle 8.3** + **[RetroFuturaGradle](https://github.com/GTNewHorizons/RetroFuturaGradle) 1.3.26** + **Forge 14.23.5.2860**.
 
 With **coremod and mixin support** that is easy to configure.
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
     id 'maven-publish'
     id 'com.diffplug.spotless' version '6.19.0' apply false
     id 'org.jetbrains.gradle.plugin.idea-ext' version '1.1.7'
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.24'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.26'
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
     id 'com.modrinth.minotaur' version '2.+' apply false
     id 'org.jetbrains.changelog' version '2.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -254,21 +254,18 @@ changelog {
     headerParserRegex.set(~/(\d+\.\d+)/)
 }
 
-tasks.register('changelogGetter', Exec) {
-    enabled !propertyBool('publish_with_changelog')
-    ext.result = {
-        if (!file('CHANGELOG.md').exists()) {
-            throw new GradleException('publish_with_changelog is true, but CHANGELOG.md does not exist in the workspace!')
-        }
-        String parsedChangelog =
-                changelog.renderItem(
-                        changelog.getLatest().withHeader(false).withEmptySections(false),
-                        Changelog.OutputType.MARKDOWN)
-        if (parsedChangelog.isEmpty()) {
-            throw new GradleException('publish_with_changelog is true, but the changelog for the latest version is empty!')
-        }
-        return parsedChangelog
+String parserChangelog() {
+    if (!file('CHANGELOG.md').exists()) {
+        throw new GradleException('publish_with_changelog is true, but CHANGELOG.md does not exist in the workspace!')
     }
+    String parsedChangelog =
+            changelog.renderItem(
+                    changelog.getLatest().withHeader(false).withEmptySections(false),
+                    Changelog.OutputType.MARKDOWN)
+    if (parsedChangelog.isEmpty()) {
+        throw new GradleException('publish_with_changelog is true, but the changelog for the latest version is empty!')
+    }
+    return parsedChangelog
 }
 
 if (propertyBool('spotless')) {

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@
  * It is advised that you do not edit anything in the build.gradle; unless you are sure of what you are doing
  */
 import com.gtnewhorizons.retrofuturagradle.mcp.InjectTagsTask
+import org.jetbrains.changelog.Changelog
 import org.jetbrains.gradle.ext.Gradle
 
 import java.time.LocalDate
@@ -251,6 +252,23 @@ test {
 changelog {
     header.set("[${propertyString('mod_version')}] - ${LocalDate.now().format("yyyy-MM-dd")}")
     headerParserRegex.set(~/(\d+\.\d+)/)
+}
+
+tasks.register('changelogGetter', Exec) {
+    enabled !propertyBool('publish_with_changelog')
+    ext.result = {
+        if (!file('CHANGELOG.md').exists()) {
+            throw new GradleException('publish_with_changelog is true, but CHANGELOG.md does not exist in the workspace!')
+        }
+        String parsedChangelog =
+                changelog.renderItem(
+                        changelog.getLatest().withHeader(false).withEmptySections(false),
+                        Changelog.OutputType.MARKDOWN)
+        if (parsedChangelog.isEmpty()) {
+            throw new GradleException('publish_with_changelog is true, but the changelog for the latest version is empty!')
+        }
+        return parsedChangelog
+    }
 }
 
 if (propertyBool('spotless')) {

--- a/build.gradle
+++ b/build.gradle
@@ -251,7 +251,7 @@ test {
 
 changelog {
     header.set("[${propertyString('mod_version')}] - ${LocalDate.now().format("yyyy-MM-dd")}")
-    headerParserRegex.set(~/(\d+\.\d+)/)
+    if (propertyString('mod_version').split("\\.").length == 2) headerParserRegex.set(~/(\d+\.\d+)/)
 }
 
 String parserChangelog() {

--- a/build.gradle
+++ b/build.gradle
@@ -258,10 +258,9 @@ String parserChangelog() {
     if (!file('CHANGELOG.md').exists()) {
         throw new GradleException('publish_with_changelog is true, but CHANGELOG.md does not exist in the workspace!')
     }
-    String parsedChangelog =
-            changelog.renderItem(
-                    changelog.getLatest().withHeader(false).withEmptySections(false),
-                    Changelog.OutputType.MARKDOWN)
+    String parsedChangelog = changelog.renderItem(
+            changelog.getLatest().withHeader(false).withEmptySections(false),
+            Changelog.OutputType.MARKDOWN)
     if (parsedChangelog.isEmpty()) {
         throw new GradleException('publish_with_changelog is true, but the changelog for the latest version is empty!')
     }

--- a/gradle/scripts/publishing.gradle
+++ b/gradle/scripts/publishing.gradle
@@ -55,15 +55,15 @@ if (propertyBool('publish_to_curseforge')) {
                 }
             }
             mainArtifact tasks.reobfJar, {
-                displayName "${propertyString('mod_name')} ${propertyString('mod_version')}"
-                if (propertyBool('use_mixins') || propertyBool('use_asset_mover')) {
+                displayName = "${propertyString('mod_name')} ${propertyString('mod_version')}"
+                if (propertyBool('use_mixins')) {
                     relations {
-                        if (propertyBool('use_mixins')) {
-                            requiredDependency 'mixin-booter'
-                        }
-                        if (propertyBool('use_asset_mover')) {
-                            requiredDependency 'assetmover'
-                        }
+                        requiredDependency 'mixin-booter'
+                    }
+                }
+                if (propertyBool('use_asset_mover')) {
+                    relations {
+                        requiredDependency 'assetmover'
                     }
                 }
             }
@@ -86,8 +86,8 @@ if (propertyBool('publish_to_modrinth')) {
         versionNumber = propertyString('mod_version')
         versionType = propertyString('release_type')
         uploadFile = tasks.reobfJar
-        gameVersions ['1.12.2']
-        loaders ['forge']
+        gameVersions = ['1.12.2']
+        loaders = ['forge']
         debugMode = propertyBool('modrinth_debug')
         if (propertyBool('use_mixins') || propertyBool('use_asset_mover')) {
             dependencies {

--- a/gradle/scripts/publishing.gradle
+++ b/gradle/scripts/publishing.gradle
@@ -47,12 +47,9 @@ if (propertyBool('publish_to_curseforge')) {
             addGameVersion 'Forge'
             addGameVersion '1.12.2'
             releaseType = propertyString('release_type')
-            if (propertyBool('publish_with_changelog')) {
-                String parsedChangelog = parseChangelog()
-                if (parsedChangelog != null) {
-                    changelogType = 'markdown'
-                    changelog = parsedChangelog
-                }
+            if (tasks.changelogGetter.enabled) {
+                changelogType = 'markdown'
+                changelog = tasks.changelogGetter.result()
             }
             mainArtifact tasks.reobfJar, {
                 displayName = "${propertyString('mod_name')} ${propertyString('mod_version')}"
@@ -99,30 +96,12 @@ if (propertyBool('publish_to_modrinth')) {
                 }
             }
         }
-        if (propertyBool('publish_with_changelog')) {
-            String parsedChangelog = parseChangelog()
-            if (parsedChangelog != null) {
-                changelog = parsedChangelog
-            }
+        if (tasks.changelogGetter.enabled) {
+            changelog = tasks.changelogGetter.result()
         }
         if (propertyBool('modrinth_sync_readme')) {
             syncBodyFrom = file('README.md').text
             tasks.modrinth.dependsOn(tasks.modrinthSyncBody)
         }
     }
-}
-
-private String parseChangelog() {
-    if (propertyBool('publish_with_changelog')) {
-        if (!file('CHANGELOG.md').exists()) {
-            throw new GradleException('publish_with_changelog is true, but CHANGELOG.md does not exist in the workspace!')
-        }
-        String parsedChangelog = changelog.renderItem(changelog.getLatest().withHeader(false).withEmptySections(false),
-                org.jetbrains.changelog.Changelog.OutputType.MARKDOWN)
-        if (parsedChangelog.isEmpty()) {
-            throw new GradleException('publish_with_changelog is true, but the changelog for the latest version is empty!')
-        }
-        return parsedChangelog
-    }
-    return null
 }

--- a/gradle/scripts/publishing.gradle
+++ b/gradle/scripts/publishing.gradle
@@ -47,9 +47,9 @@ if (propertyBool('publish_to_curseforge')) {
             addGameVersion 'Forge'
             addGameVersion '1.12.2'
             releaseType = propertyString('release_type')
-            if (tasks.changelogGetter.enabled) {
+            if (!propertyBool('publish_with_changelog')) {
+                changelog = parserChangelog()
                 changelogType = 'markdown'
-                changelog = tasks.changelogGetter.result()
             }
             mainArtifact tasks.reobfJar, {
                 displayName = "${propertyString('mod_name')} ${propertyString('mod_version')}"
@@ -96,8 +96,8 @@ if (propertyBool('publish_to_modrinth')) {
                 }
             }
         }
-        if (tasks.changelogGetter.enabled) {
-            changelog = tasks.changelogGetter.result()
+        if (!propertyBool('publish_with_changelog')) {
+            changelog = parserChangelog()
         }
         if (propertyBool('modrinth_sync_readme')) {
             syncBodyFrom = file('README.md').text

--- a/gradle/scripts/publishing.gradle
+++ b/gradle/scripts/publishing.gradle
@@ -39,7 +39,7 @@ if (propertyBool('publish_to_curseforge')) {
     assertProperty('release_type')
     setDefaultProperty('curseforge_debug', false, false)
     curseforge {
-        apiKey System.getenv('CURSEFORGE_TOKEN')
+        apiKey = System.getenv('CURSEFORGE_TOKEN') == null ? "" : System.getenv('CURSEFORGE_TOKEN')
         // noinspection GroovyAssignabilityCheck
         project {
             id = propertyString('curseforge_project_id')
@@ -81,7 +81,7 @@ if (propertyBool('publish_to_modrinth')) {
     assertProperty('release_type')
     setDefaultProperty('modrinth_debug', false, false)
     modrinth {
-        token = System.getenv('MODRINTH_TOKEN')
+        token = System.getenv('MODRINTH_TOKEN') ? "" : System.getenv('MODRINTH_TOKEN')
         projectId = propertyString('modrinth_project_id')
         versionNumber = propertyString('mod_version')
         versionType = propertyString('release_type')


### PR DESCRIPTION
This patch featuring:
- Allow Gradle to run where some tasks required environment variable but they are not available at moment.
- Fix changelog parser, refactor to `build.gradle` as function,
- Correct Changelog's header parser setting based on mod version.
- Inject secret to GHA tasks since they are not inject automatically.
- Update RFG, cleanup README.