### PR TITLE
fix refmap name in generated mixin config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -283,7 +283,7 @@ tasks.register('generateMixinJson') {
     doLast {
         for (String mixinConfig : missingConfig) {
             def file = file("src/main/resources/mixins.${mixinConfig}.json")
-            file << """{\n\t"package": "",\n\t"required": true,\n\t"refmap": "${mixin_refmap}",\n\t"target": "@env(DEFAULT)",\n\t"minVersion": "0.8.5",\n\t"compatibilityLevel": "JAVA_8",\n\t"mixins": [],\n\t"server": [],\n\t"client": []\n}"""
+            file << """{\n\t"package": "",\n\t"required": true,\n\t"refmap": "${propertyString('mixin_refmap')}",\n\t"target": "@env(DEFAULT)",\n\t"minVersion": "0.8.5",\n\t"compatibilityLevel": "JAVA_8",\n\t"mixins": [],\n\t"server": [],\n\t"client": []\n}"""
         }
     }
 }


### PR DESCRIPTION
using `propertyString(...)` to handle template string properly