### PR TITLE
Invert conditions for publishing with changelog

### DIFF
--- a/gradle/scripts/publishing.gradle
+++ b/gradle/scripts/publishing.gradle
@@ -47,7 +47,7 @@ if (propertyBool('publish_to_curseforge')) {
             addGameVersion 'Forge'
             addGameVersion '1.12.2'
             releaseType = propertyString('release_type')
-            if (!propertyBool('publish_with_changelog')) {
+            if (propertyBool('publish_with_changelog')) {
                 changelog = parserChangelog()
                 changelogType = 'markdown'
             }
@@ -96,7 +96,7 @@ if (propertyBool('publish_to_modrinth')) {
                 }
             }
         }
-        if (!propertyBool('publish_with_changelog')) {
+        if (propertyBool('publish_with_changelog')) {
             changelog = parserChangelog()
         }
         if (propertyBool('modrinth_sync_readme')) {


### PR DESCRIPTION
In `gradle.properties`, the property is defined as:
`publish_with_changelog = ${{ it.file('CHANGELOG.md').exists() }}`
This correctly returns `true` when `CHANGELOG.md` exists in the project root.

However, the condition in both the CurseForge and Modrinth publishing blocks is inverted:

```
if (!propertyBool('publish_with_changelog')) {
    changelog = parserChangelog()
}
```

This means when `CHANGELOG.md` **exists** (`publish_with_changelog = true`), the `!` inverts it to `false` and the changelog is never attached to the upload.

As a side effect, if `CHANGELOG.md` is **absent** (`publish_with_changelog = false`), the `!` inverts it to `true`, triggering `parserChangelog()` from `build.gradle` which immediately throws exception, because it's also has file existence check:
```
String parserChangelog() {
    if (!file('CHANGELOG.md').exists()) {
        throw new GradleException('publish_with_changelog is true, but CHANGELOG.md does not exist in the workspace!')
    }
// ...Rest of the parser...
}
```
_(Yes, the message is also comes a bit misleading)_

**Fix**: remove the ! from both conditions.