### PR TITLE
Force enable decompression when there's no source available

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ base {
     archivesName.set(propertyString('mod_id'))
 }
 
-tasks.decompressDecompiledSources.enabled !propertyBool('change_minecraft_sources')
+tasks.decompressDecompiledSources.enabled !propertyBool('change_minecraft_sources') || !project.file("./build/rfg/minecraft-src").exists()
 
 java {
     toolchain {


### PR DESCRIPTION
`change_minecraft_sources` works by preventing re-generation of decompressed source, which will cause major issue when there's no existed sources. After running `gradlew clean`, or when initializing the project freshly, a new decompressed source is supposed to be copied into `./build/rfg/minecraft-src` folder, but enabling `change_minecraft_sources` will break this.

This PR fixes this by simply detecting whether such folder exists, and force-enable decompression when not.