### PR TITLE
switch from Jabel to JVMDowngrader

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@
  * It is advised that you do not edit anything in the build.gradle; unless you are sure of what you are doing
  */
 import com.gtnewhorizons.retrofuturagradle.mcp.InjectTagsTask
+import com.gtnewhorizons.retrofuturagradle.mcp.ReobfuscatedJar
+import com.gtnewhorizons.retrofuturagradle.minecraft.RunMinecraftTask
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.gradle.ext.Gradle
 
@@ -15,6 +17,7 @@ plugins {
     id 'com.modrinth.minotaur' version '2.+' apply false
     id 'org.jetbrains.changelog' version '2.5.0'
     id 'com.gradleup.shadow' version '9.4.+'
+    id 'xyz.wagyourtail.jvmdowngrader' version '1.3.6' apply false
 }
 
 apply from: 'gradle/scripts/helpers.gradle'
@@ -32,6 +35,7 @@ assertSubProperties 'is_coremod', 'coremod_includes_mod', 'coremod_plugin_class_
 assertSubProperties 'use_asset_mover', 'asset_mover_version'
 
 setDefaultProperty 'use_modern_java_syntax', false, false
+setDefaultProperty 'modern_java_version', true, '25'
 setDefaultProperty 'generate_sources_jar', true, false
 setDefaultProperty 'generate_javadocs_jar', true, false
 setDefaultProperty 'mapping_channel', true, 'stable'
@@ -41,6 +45,10 @@ setDefaultProperty 'minecraft_username', true, 'Developer'
 setDefaultProperty 'extra_jvm_args', false, ''
 setDefaultProperty 'extra_tweak_classes', false, ''
 setDefaultProperty 'change_minecraft_sources', false, false
+
+if (propertyBool('use_modern_java_syntax')) {
+    apply(plugin: 'xyz.wagyourtail.jvmdowngrader')
+}
 
 version = propertyString('mod_version')
 group = propertyString('root_package')
@@ -53,7 +61,7 @@ tasks.decompressDecompiledSources.enabled !propertyBool('change_minecraft_source
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(propertyBool('use_modern_java_syntax') ? 16 : 8))
+        languageVersion.set(JavaLanguageVersion.of(propertyBool('use_modern_java_syntax') ? propertyString("modern_java_version") : 8))
         // Azul covers the most platforms for Java 8 toolchains, crucially including MacOS arm64
         vendor.set(JvmVendorSpec.AZUL)
     }
@@ -111,19 +119,8 @@ repositories {
 
 dependencies {
     if (propertyBool('use_modern_java_syntax')) {
-        annotationProcessor 'com.github.bsideup.jabel:jabel-javac-plugin:1.0.0'
-        // Workaround for https://github.com/bsideup/jabel/issues/174
-        annotationProcessor 'net.java.dev.jna:jna-platform:5.13.0'
-        compileOnly ('com.github.bsideup.jabel:jabel-javac-plugin:1.0.0') {
-            transitive = false
-        }
         // Allow jdk.unsupported classes like sun.misc.Unsafe, workaround for JDK-8206937 and fixes crashes in tests
         patchedMinecraft 'me.eigenraven.java8unsupported:java-8-unsupported-shim:1.0.0'
-        // Include for tests
-        testAnnotationProcessor 'com.github.bsideup.jabel:jabel-javac-plugin:1.0.0'
-        testCompileOnly('com.github.bsideup.jabel:jabel-javac-plugin:1.0.0') {
-            transitive = false // We only care about the 1 annotation class
-        }
     }
     if (propertyBool('use_asset_mover')) {
         implementation "com.cleanroommc:assetmover:${propertyString('asset_mover_version')}"
@@ -305,12 +302,7 @@ tasks.withType(JavaCompile).configureEach {
         if (it.name in ['compileMcLauncherJava', 'compilePatchedMcJava']) {
             return
         }
-        sourceCompatibility = 17
-        options.release.set(8)
-        javaCompiler.set(javaToolchains.compilerFor {
-            languageVersion.set(JavaLanguageVersion.of(16))
-            vendor.set(JvmVendorSpec.AZUL)
-        })
+        sourceCompatibility = propertyString('modern_java_version')
     }
 }
 
@@ -321,7 +313,20 @@ tasks.register('cleanroomAfterSync') {
 
 if (propertyBool('use_modern_java_syntax')) {
     tasks.withType(Javadoc).configureEach {
-        sourceCompatibility = 17
+        sourceCompatibility = propertyString('modern_java_version')
+    }
+    // downgrade code for build
+    tasks.named('reobfJar', ReobfuscatedJar) {
+        inputJar.set((shadeDowngradedApi as Jar).archiveFile)
+        dependsOn(shadeDowngradedApi)
+    }
+    // downgrade code for runClient/runServer
+    // modern run task, e.g. runClient17, are left as-is, to allow dev to test raw (before downgrading) logic
+    for (runTask in ['runClient', 'runServer']) {
+        tasks.named(runTask, RunMinecraftTask) {
+            classpath = classpath - layout.files(jar) + layout.files(shadeDowngradedApi)
+            dependsOn(shadeDowngradedApi)
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -321,7 +321,6 @@ if (propertyBool('use_modern_java_syntax')) {
         dependsOn(shadeDowngradedApi)
     }
     // downgrade code for runClient/runServer
-    // modern run task, e.g. runClient17, are left as-is, to allow dev to test raw (before downgrading) logic
     for (runTask in ['runClient', 'runServer']) {
         tasks.named(runTask, RunMinecraftTask) {
             classpath = classpath - layout.files(jar) + layout.files(shadeDowngradedApi)

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,9 @@
 org.gradle.jvmargs = -Xmx3G
 
 # Source Options
-# Use Modern Java(9+) Syntax (Courtesy of Jabel)
-use_modern_java_syntax = false
+# Use Modern Java(9+) Syntax and APIs (Courtesy of JVMDowngrader)
+use_modern_java_syntax = true
+modern_java_version = 25
 
 # Compilation Options
 generate_sources_jar = true


### PR DESCRIPTION
closes #56 

Title.

## Known Issues (the reason this is a draft)
- Tests do not work, as the sources do not get downgraded. I don't know how to fix that.

## Other stuff
- Shaded deps get downgraded so that's nice.
- I hesitated removing the `use_modern_java_syntax` property and replacing it with just `source_java_version` that enables JVMDowngrader if it is > 9. Don't know if it would be better