### PR TITLE
Add property to include JetBrains annotations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ assertSubProperties 'is_coremod', 'coremod_includes_mod', 'coremod_plugin_class_
 assertSubProperties 'use_asset_mover', 'asset_mover_version'
 
 setDefaultProperty 'use_modern_java_syntax', false, false
+setDefaultProperty 'use_jetbrains_annotations', false, false
 setDefaultProperty 'generate_sources_jar', true, false
 setDefaultProperty 'generate_javadocs_jar', true, false
 setDefaultProperty 'mapping_channel', true, 'stable'
@@ -124,6 +125,9 @@ dependencies {
         testCompileOnly('com.github.bsideup.jabel:jabel-javac-plugin:1.0.0') {
             transitive = false // We only care about the 1 annotation class
         }
+    }
+    if (propertyBool('use_jetbrains_annotations')) {
+        compileOnly 'org.jetbrains:annotations:26.1.0'
     }
     if (propertyBool('use_asset_mover')) {
         implementation "com.cleanroommc:assetmover:${propertyString('asset_mover_version')}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,9 @@ org.gradle.jvmargs = -Xmx3G
 # Source Options
 # Use Modern Java(9+) Syntax (Courtesy of Jabel)
 use_modern_java_syntax = false
+# Convenient annotations for JVM-based languages
+# Documentation: https://github.com/JetBrains/java-annotations
+use_jetbrains_annotations = false
 
 # Compilation Options
 generate_sources_jar = true


### PR DESCRIPTION
Very nice annotations, used a lot by mods for newer minecraft versions. After getting used to them, not having access to them can be kinda annoying sometimes :P

They're included with `mavenCentral()` so no need to add a new maven repository

https://github.com/JetBrains/java-annotations