### PR TITLE
Add unsaved Kate files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ out
 build
 .gradle
 
+# kate
+*.kate-swp
+
 # other
 eclipse
 run


### PR DESCRIPTION
Kate is the default text editor for the KDE Plasma desktop environment for Linux:

https://kate-editor.org/

While editing a file, Kate creates a hidden file with a `.kate-swp` extension (until the changes are either saved or discarded). This PR adds those to the gitignore, so they aren't accidentally pushed.