### PR TITLE
Update mixin_booter_version to 11.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -105,7 +105,7 @@ access_transformer_locations = ${mod_id}_at.cfg
 # Wiki: https://github.com/SpongePowered/Mixin/wiki + https://github.com/CleanroomMC/MixinBooter/ + https://cleanroommc.com/wiki/forge-mod-development/mixin/preface
 # Only use mixins once you understand the underlying structure
 use_mixins = false
-mixin_booter_version = 10.7
+mixin_booter_version = 11.2
 # A configuration defines a mixin set, and you may have as many mixin sets as you require for your application.
 # Each config can only have one and only one package root.
 # Generate missing configs, obtain from mixin_configs and generate file base on name convention: "mixins.config_name.json"


### PR DESCRIPTION
This previously caused mixins to not apply in my project. Updating mixin booter to this version resolved that issue. 

If this shouldn't be updated, I'd love to understand why.

Hopefully this is helpful to the next person using FDE for the first time.